### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [UNRELEASED]
+
+## [0.0.2]
 ### Removed
 - init function from all commands to prevent unexpected behaviors during test
 
@@ -18,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defect Dojo Exporter pkg
 - Export command to CLI
 - Environment variables for Defect Dojo exporter
+- GitHub Action for testing
 
 ## [0.0.1] - 2022-06-28
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # Gate Check
+[![CICD Pipeline](https://github.com/gatecheckdev/gatecheck/actions/workflows/run-test.yaml/badge.svg?branch=main)](https://github.com/gatecheckdev/gatecheck/actions/workflows/run-test.yaml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/gatecheckdev/gatecheck.svg)](https://pkg.go.dev/github.com/gatecheckdev/gatecheck)
+[![Go Report Card](https://goreportcard.com/badge/github.com/gatecheckdev/gatecheck)](https://goreportcard.com/report/github.com/gatecheckdev/gatecheck)
+
 
 ![Gate Check Logo](static/gatecheck-logo.png)
 
@@ -11,6 +15,7 @@ Gate Check is stateless so self-hosting and provisioning servers is not required
 
 - [X] Report Aggregation
 - [X] Vulnerability Threshold Configuration
+- [X] Report Exporting
 - [ ] Asset bundling
 - [ ] Artifact Integrity Verification
 - [ ] Whitelist Management
@@ -63,6 +68,10 @@ gatecheck report print --report gatecheck-report.json
 
 Exporting will take the report and upload it to a specific target location using the API.
 Custom exporters can be created by simply implementing the Exporter interface.
+
+```shell
+gatecheck export defect-dojo grype grype-report.json
+```
 
 ### Defect Dojo
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,7 @@ import (
 
 // Defaults
 
-const VersionNumber = "0.0.1"
+const VersionNumber = "0.0.2"
 const DefaultReportFile = "gatecheck-report.json"
 const DefaultConfigFile = "gatecheck.yaml"
 


### PR DESCRIPTION
### Removed
- init function from all commands to prevent unexpected behaviors during test

### Changed
- Commands have a wrapper function to inject arguments
- Internal/Util test package uses a ReadCloser interface
- Updated cmd unit tests to use ReadCloser to open test files

### Added
- Exporter pkg
- Defect Dojo Exporter pkg
- Export command to CLI
- Environment variables for Defect Dojo exporter
- GitHub Action for testing