### PR TITLE
feat: allow-missing flag to bundle command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Debugs in CLI commands
 - Make commands for test and coverage
 - Allow Deny List for Grype reports
+- 'allow-missing' flag to bundle command
 
 ## [0.0.9] - 2023-02-06
 

--- a/cmd/bundle_test.go
+++ b/cmd/bundle_test.go
@@ -116,6 +116,16 @@ func TestNewBundleCmd(t *testing.T) {
 			t.Log(output)
 		})
 
+		t.Run("allow-missing", func(t *testing.T) {
+			someFile := path.Join(t.TempDir(), "some.file")
+
+			commandString := fmt.Sprintf("bundle -mvo %s %s", outFile, someFile)
+			output, err := Execute(commandString, CLIConfig{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Log(output)
+		})
 	})
 
 }

--- a/cmd/gatecheck/main.go
+++ b/cmd/gatecheck/main.go
@@ -54,7 +54,7 @@ func main() {
 
 	command.PersistentPreRun = func(_ *cobra.Command, _ []string) {
 		if cmd.GlobalVerboseOutput == false {
-			log.SetLogLevel(log.Disabled)
+			log.SetLogLevel(log.WarnLevel)
 		}
 		log.StartCLIOutput(command.ErrOrStderr())
 	}


### PR DESCRIPTION
Using the allow-missing flag will prevent errors in a CI/CD pipeline when adding report files who existence is non-deterministic.

#14 