### PR TITLE
feat: Add sorting capability to the table and sort grype print and epss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New ASCII Logo
 - Bundle logging to use internal logger
+- Sort Grype print by Severity, then by Package
 
 ### Added
 
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make commands for test and coverage
 - Allow Deny List for Grype reports
 - 'allow-missing' flag to bundle command
+- Sort tables by single or multiple columns in ascending, descending or custom order
 
 ## [0.0.9] - 2023-02-06
 

--- a/pkg/artifact/bundle.go
+++ b/pkg/artifact/bundle.go
@@ -7,10 +7,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/dustin/go-humanize"
-	gcStrings "github.com/gatecheckdev/gatecheck/pkg/strings"
 	"io"
 	"strings"
+
+	"github.com/dustin/go-humanize"
+	gcStrings "github.com/gatecheckdev/gatecheck/pkg/strings"
 )
 
 type Bundle struct {

--- a/pkg/artifact/grype-scan-report.go
+++ b/pkg/artifact/grype-scan-report.go
@@ -22,6 +22,13 @@ func (r GrypeScanReport) String() string {
 			item.Artifact.Name, item.Artifact.Version, item.Vulnerability.DataSource)
 	}
 
+	// Sort the rows by Severity then Package
+	severitiesOrder := gcStrings.StrOrder{"Critical", "High", "Medium", "Low", "Negligible", "Unknown"}
+	table = table.SortBy([]gcStrings.SortBy{
+		{Name: "Severity", Mode: gcStrings.AscCustom, Order: severitiesOrder},
+		{Name: "Package", Mode: gcStrings.Asc},
+	}).Sort()
+
 	return table.String()
 }
 

--- a/pkg/epss/service_test.go
+++ b/pkg/epss/service_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 )
 
 const FirstAPIURL = "https://api.first.org/data/v1/epss"
@@ -95,64 +94,6 @@ func TestFirstAPIService_BadServerResponseJSON(t *testing.T) {
 	if errors.Is(err, ErrAPIPartialFail) != true {
 		t.Fatal(err)
 	}
-}
-
-func TestSort(t *testing.T) {
-	layout := "2006-01-02"
-	now := time.Now()
-	data := []Data{
-		{CVE: "C", EPSS: ".02", Percentile: ".3", Date: now.Add(time.Hour * -48).Format(layout)},
-		{CVE: "B", EPSS: ".01", Percentile: ".76", Date: now.Format(layout)},
-		{CVE: "A", EPSS: ".06", Percentile: ".88", Date: now.Add(time.Hour * -24).Format(layout)},
-	}
-
-	t.Run("sort-by-cve", func(t *testing.T) {
-		tempData := make([]Data, 3)
-		_ = copy(tempData, data)
-		Sort(tempData, SortCVE)
-		expected := []string{"C", "B", "A"}
-		for i := range tempData {
-			if tempData[i].CVE == expected[i] != true {
-				t.Fatalf("Sort failed:\n%+v\n", tempData)
-			}
-		}
-	})
-
-	t.Run("sort-by-EPSS", func(t *testing.T) {
-		tempData := make([]Data, 3)
-		_ = copy(tempData, data)
-		Sort(tempData, SortEPSS)
-		expected := []string{"A", "C", "B"}
-		for i := range tempData {
-			if tempData[i].CVE == expected[i] != true {
-				t.Fatalf("Sort failed:\n%+v\n", tempData)
-			}
-		}
-	})
-
-	t.Run("sort-by-Percentile", func(t *testing.T) {
-		tempData := make([]Data, 3)
-		_ = copy(tempData, data)
-		Sort(tempData, SortPercentile)
-		expected := []string{"A", "B", "C"}
-		for i := range tempData {
-			if tempData[i].CVE == expected[i] != true {
-				t.Fatalf("Sort failed:\n%+v\n", tempData)
-			}
-		}
-	})
-
-	t.Run("sort-by-Date", func(t *testing.T) {
-		tempData := make([]Data, 3)
-		_ = copy(tempData, data)
-		Sort(tempData, SortDate)
-		expected := []string{"B", "A", "C"}
-		for i := range tempData {
-			if tempData[i].CVE == expected[i] != true {
-				t.Fatalf("Sort failed:\n%+v\n", tempData)
-			}
-		}
-	})
 }
 
 func mockClient(handlerFunc func(http.ResponseWriter, *http.Request)) *httptest.Server {

--- a/pkg/strings/sort-table.go
+++ b/pkg/strings/sort-table.go
@@ -1,0 +1,143 @@
+package strings
+
+import (
+	"sort"
+	"strconv"
+)
+
+type SortBy struct {
+	Name   string
+	Number int
+	Mode   SortMode
+	Order  StrOrder
+}
+
+// StrOrder defines a custom index to sort by. 	Ex: StrOrder{"Hot", "Warm", "Cold"}
+type StrOrder []string
+
+// SortMode defines How to sort.
+type SortMode int
+
+const (
+	// Asc sorts the column in Ascending order alphabetically.
+	Asc SortMode = iota
+	// AscNumeric sorts the column in Ascending order numerically.
+	AscNumeric
+	// Custom sorts the column in Ascending order by custom string index order
+	AscCustom
+	// Dsc sorts the column in Descending order alphabetically.
+	Dsc
+	// DscNumeric sorts the column in Descending order numerically.
+	DscNumeric
+	// Custom sorts the column in Descending order by custom string index order
+	DscCustom
+)
+
+type rowsSorter struct {
+	rows          [][]string
+	sortBy        []SortBy
+	sortedIndices []int
+}
+
+// getSortedRowIndices sorts and returns the row indices in Sorted order as
+// directed by Table.sortBy which can be set using Table.SortBy(...)
+func (t *Table) getSortedRowIndices() []int {
+	sortedIndices := make([]int, len(t.rows))
+	for idx := range t.rows {
+		sortedIndices[idx] = idx
+	}
+
+	if t.sortBy != nil && len(t.sortBy) > 0 {
+		sort.Sort(rowsSorter{
+			rows:          t.rows,
+			sortBy:        t.parseSortBy(t.sortBy),
+			sortedIndices: sortedIndices,
+		})
+	}
+
+	return sortedIndices
+}
+
+func (t *Table) parseSortBy(sortBy []SortBy) []SortBy {
+	var resSortBy []SortBy
+	for _, col := range sortBy {
+		colNum := 0
+		if col.Number > 0 && col.Number <= t.numColumns {
+			colNum = col.Number
+		} else if col.Name != "" && len(t.headerItems) > 0 {
+			for idx, colName := range t.headerItems {
+				if col.Name == colName {
+					colNum = idx + 1
+					break
+				}
+			}
+		}
+		if colNum > 0 {
+			resSortBy = append(resSortBy, SortBy{
+				Name:   col.Name,
+				Number: colNum,
+				Mode:   col.Mode,
+				Order:  col.Order,
+			})
+		}
+	}
+	return resSortBy
+}
+
+func (rs rowsSorter) Len() int {
+	return len(rs.rows)
+}
+
+func (rs rowsSorter) Swap(i, j int) {
+	rs.sortedIndices[i], rs.sortedIndices[j] = rs.sortedIndices[j], rs.sortedIndices[i]
+}
+
+func (rs rowsSorter) Less(i, j int) bool {
+	realI, realJ := rs.sortedIndices[i], rs.sortedIndices[j]
+	for _, col := range rs.sortBy {
+		rowI, rowJ, colIdx := rs.rows[realI], rs.rows[realJ], col.Number-1
+		if colIdx < len(rowI) && colIdx < len(rowJ) {
+			shouldContinue, returnValue := rs.lessColumns(rowI, rowJ, colIdx, col)
+			if !shouldContinue {
+				return returnValue
+			}
+		}
+	}
+	return false
+}
+
+func (rs rowsSorter) lessColumns(rowI []string, rowJ []string, colIdx int, col SortBy) (bool, bool) {
+	if rowI[colIdx] == rowJ[colIdx] {
+		return true, false
+	} else if col.Mode == Asc {
+		return false, rowI[colIdx] < rowJ[colIdx]
+	} else if col.Mode == Dsc {
+		return false, rowI[colIdx] > rowJ[colIdx]
+	} else if col.Mode == AscCustom {
+		return false, col.Order.index(rowI[colIdx]) < col.Order.index(rowJ[colIdx])
+	} else if col.Mode == DscCustom {
+		return false, col.Order.index(rowI[colIdx]) > col.Order.index(rowJ[colIdx])
+	}
+
+	// Sort Numerically
+	iVal, iErr := strconv.ParseFloat(rowI[colIdx], 64)
+	jVal, jErr := strconv.ParseFloat(rowJ[colIdx], 64)
+	if iErr == nil && jErr == nil {
+		if col.Mode == AscNumeric {
+			return false, iVal < jVal
+		} else if col.Mode == DscNumeric {
+			return false, jVal < iVal
+		}
+	}
+	return true, false
+}
+
+// Finds the index of a string in an array
+func (strOrder StrOrder) index(s string) int {
+	for i, str := range strOrder {
+		if str == s {
+			return i
+		}
+	}
+	return 0
+}

--- a/pkg/strings/sort-table_test.go
+++ b/pkg/strings/sort-table_test.go
@@ -1,0 +1,146 @@
+package strings
+
+import (
+	"testing"
+)
+
+func TestSortTable_SingleCol(t *testing.T) {
+	table := NewTable("ColumnName")
+	table = table.WithRow("C")
+	table = table.WithRow("B")
+	table = table.WithRow("A")
+
+	expected := [][]string{{"C"}, {"B"}, {"A"}}
+
+	for idx, str := range table.rows {
+		if expected[idx][0] != str[0] {
+			t.Fatal("Expected", expected[idx][0], "got", str[0])
+		}
+	}
+
+	expected = [][]string{{"A"}, {"B"}, {"C"}}
+
+	table = table.SortBy([]SortBy{
+		{Name: "ColumnName", Mode: Asc},
+	}).Sort()
+
+	for idx, str := range table.rows {
+		if expected[idx][0] != str[0] {
+			t.Fatal("Expected", expected[idx][0], "got", str[0])
+		}
+	}
+
+	expected = [][]string{{"C"}, {"B"}, {"A"}}
+
+	table = table.SortBy([]SortBy{
+		{Name: "ColumnName", Mode: Dsc},
+	}).Sort()
+
+	for idx, str := range table.rows {
+		if expected[idx][0] != str[0] {
+			t.Fatal("Expected", expected[idx][0], "got", str[0])
+		}
+	}
+
+}
+
+func TestSortTable_CustomSort(t *testing.T) {
+	table := NewTable("ColumnName")
+	table = table.WithRow("Cold")
+	table = table.WithRow("Hot")
+	table = table.WithRow("Warm")
+	table = table.WithRow("Hot")
+
+	expected := [][]string{
+		{"Cold"},
+		{"Hot"},
+		{"Warm"},
+		{"Hot"},
+	}
+
+	for idx, str := range table.rows {
+		if expected[idx][0] != str[0] {
+			t.Fatal("Expected", expected[idx][0], "got", str[0])
+		}
+	}
+
+	expected = [][]string{
+		{"Hot"},
+		{"Hot"},
+		{"Warm"},
+		{"Cold"},
+	}
+
+	table = table.SortBy([]SortBy{
+		{Name: "ColumnName", Mode: AscCustom, Order: StrOrder{"Hot", "Warm", "Cold"}},
+	}).Sort()
+
+	for idx, str := range table.rows {
+		if expected[idx][0] != str[0] {
+			t.Fatal("Expected", expected[idx][0], "got", str[0])
+		}
+	}
+}
+
+func TestSortTable_MultiCol(t *testing.T) {
+	table := NewTable("ColumnName", "Value")
+	table = table.WithRow("B", "2")
+	table = table.WithRow("B", "1")
+	table = table.WithRow("A", "1")
+	table = table.WithRow("A", "2")
+
+	expected := [][]string{
+		{"B", "2"},
+		{"B", "1"},
+		{"A", "1"},
+		{"A", "2"},
+	}
+
+	for i, row := range table.rows {
+		for j := range row {
+			if expected[i][j] != table.rows[i][j] {
+				t.Fatal("Expected", expected[i][j], "got", table.rows[i][j])
+			}
+		}
+	}
+
+	expected = [][]string{
+		{"A", "1"},
+		{"A", "2"},
+		{"B", "1"},
+		{"B", "2"},
+	}
+
+	table = table.SortBy([]SortBy{
+		{Name: "ColumnName", Mode: Asc},
+		{Name: "Value", Mode: Asc},
+	}).Sort()
+
+	for i, row := range table.rows {
+		for j := range row {
+			if expected[i][j] != table.rows[i][j] {
+				t.Fatal("Expected", expected[i][j], "got", table.rows[i][j])
+			}
+		}
+	}
+
+	expected = [][]string{
+		{"B", "1"},
+		{"B", "2"},
+		{"A", "1"},
+		{"A", "2"},
+	}
+
+	table = table.SortBy([]SortBy{
+		{Name: "ColumnName", Mode: Dsc},
+		{Name: "Value", Mode: Asc},
+	}).Sort()
+
+	for i, row := range table.rows {
+		for j := range row {
+			if expected[i][j] != table.rows[i][j] {
+				t.Fatal("Expected", expected[i][j], "got", table.rows[i][j])
+			}
+		}
+	}
+}

--- a/pkg/strings/table.go
+++ b/pkg/strings/table.go
@@ -8,19 +8,50 @@ import (
 type Table struct {
 	headerItems []string
 	rows        [][]string
+
+	sortBy     []SortBy
+	numColumns int
 }
 
 func NewTable(header ...string) *Table {
-	return &Table{headerItems: header}
+	return &Table{
+		headerItems: header,
+		numColumns:  len(header),
+	}
 }
 
 func (t Table) WithHeader(items ...string) *Table {
 	t.headerItems = items
+	t.numColumns = len(items)
 	return &t
 }
 
 func (t Table) WithRow(row ...string) *Table {
 	t.rows = append(t.rows, row)
+	return &t
+}
+
+// SortBy sets the rules for sorting the Rows in the order specified. i.e., the
+// first SortBy instruction takes precedence over the second and so on. Any
+// duplicate instructions on the same column will be discarded while sorting.
+func (t Table) SortBy(sortBy []SortBy) *Table {
+	t.sortBy = sortBy
+	return &t
+}
+
+func (t Table) Sort() *Table {
+	if len(t.sortBy) == 0 {
+		return &t
+	}
+
+	// sort the rows
+	sortedRowIndices := t.getSortedRowIndices()
+	sortedRows := make([][]string, len(t.rows))
+	for idx := range t.rows {
+		sortedRows[idx] = t.rows[sortedRowIndices[idx]]
+	}
+	t.rows = sortedRows
+
 	return &t
 }
 

--- a/pkg/strings/table_test.go
+++ b/pkg/strings/table_test.go
@@ -10,6 +10,12 @@ func TestTable_WithHeader(t *testing.T) {
 	table = table.WithRow("A", "B", "C", "len of 8")
 	table = table.WithRow("Some longer A", "Text in the B", "Rows than the header C", "D")
 
+	numColumns := table.numColumns
+	expectedColumns := 5
+	if numColumns != expectedColumns {
+		t.Fatal("Number of columns expected", expectedColumns, "got", numColumns)
+	}
+
 	colLengths := table.columnLengths()
 	expectedLengths := []int{13, 13, 22, 8, 4}
 	for i := range table.columnLengths() {


### PR DESCRIPTION
- Add single and multi-column sorting to string table
- Move epss print over to using table sort
- Sort Grype by Severity (logical sort), then by package name

#16 