### PR TITLE
fix: rollback export s3 and epss changes

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"time"
 
-	gio "github.com/gatecheckdev/gatecheck/internal/io"
 	"github.com/gatecheckdev/gatecheck/internal/log"
 	"github.com/gatecheckdev/gatecheck/pkg/artifacts/cyclonedx"
 	"github.com/gatecheckdev/gatecheck/pkg/artifacts/gitleaks"
@@ -96,13 +95,18 @@ func NewExportCmd(
 		Short: "Export raw scan report to AWS S3",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Open the file
+			f, err := os.Open(args[0])
+			if err != nil {
+				return fmt.Errorf("%w: %v", ErrorFileAccess, err)
+			}
 
 			objectKey, _ := cmd.Flags().GetString("key")
 
 			ctx, cancel := context.WithTimeout(context.Background(), awsTimeout)
 			defer cancel()
 
-			return awsService.Export(ctx, gio.NewLazyReader(args[0]), objectKey)
+			return awsService.Export(ctx, f, objectKey)
 		},
 	}
 	awsCmd.Flags().String("key", "", "The AWS S3 object key for the location in the bucket")

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -116,17 +116,29 @@ func TestNewExport_DDCmd(t *testing.T) {
 }
 
 func TestExportS3Cmd(t *testing.T) {
-	config := CLIConfig{
-		AWSExportService: mockAWSExportService{exportResponse: nil},
-		AWSExportTimeout: time.Second * 3,
-	}
+	t.Run("success", func(t *testing.T) {
+		f := MustOpen(grypeTestReport, t)
 
-	commandString := fmt.Sprintf("export s3 %s --key a/b/c", grypeTestReport)
+		commandString := fmt.Sprintf("export s3 %s --key a/b/c", f.Name())
 
-	_, err := Execute(commandString, config)
-	if err != nil {
-		t.Fatal(err)
-	}
+		_, err := Execute(commandString, CLIConfig{
+			AWSExportService: mockAWSExportService{exportResponse: nil},
+			AWSExportTimeout: time.Second * 3,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("bad-permissions", func(t *testing.T) {
+		commandString := fmt.Sprintf("export s3 %s --key a/b/c", fileWithBadPermissions(t))
+		out, err := Execute(commandString, CLIConfig{})
+
+		if errors.Is(err, ErrorFileAccess) != true {
+			t.Log(out)
+			t.Fatal(err)
+		}
+	})
 }
 
 func AsyncDecoderFunc() AsyncDecoder {

--- a/pkg/epss/service.go
+++ b/pkg/epss/service.go
@@ -202,7 +202,7 @@ func (a *APIAgent) Read(p []byte) (int, error) {
 		return a.gunzipReader.Read(p)
 	}
 
-	today := time.Now().UTC()
+	today := time.Now()
 	endpoint := fmt.Sprintf("epss_scores-%d-%s-%s.csv.gz", today.Year(), today.Format("01"), today.Format("02"))
 	url, _ := url.JoinPath(a.url, endpoint)
 	req, _ := http.NewRequest(http.MethodGet, url, nil)


### PR DESCRIPTION
- rollback export s3 lazyreader changes due to AWS SDK not playing nice
- rollback epss timezone changes

Signed-off-by: Chaz Leong <13462818+cleong14@users.noreply.github.com>
