### PR TITLE
32 gitleaks report artifact encodingdecoding errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Bug where Gitleaks report with no secrets aren't properly decoded
+
 ## [0.1.3] - 2023-08-04
 
 ### Fixed

--- a/cmd/gatecheck/main.go
+++ b/cmd/gatecheck/main.go
@@ -31,7 +31,7 @@ const ExitSystemFail int = -1
 const ExitOk int = 0
 const ExitFileAccessFail int = 2
 const ExitValidationFail = 1
-const GatecheckVersion = "v0.1.3"
+const GatecheckVersion = "v0.1.4-pre"
 
 func main() {
 	viper.SetConfigType("env")

--- a/cmd/print_test.go
+++ b/cmd/print_test.go
@@ -46,6 +46,18 @@ func Test_PrintCommand(t *testing.T) {
 		}
 		t.Log(out)
 	})
+	t.Run("gitleaks_no_secrets", func(t *testing.T) {
+		fn := path.Join(t.TempDir(), "gitleaks-report.json")
+		f := MustCreate(fn, t)
+		f.WriteString("[]\n")
+		f.Close()
+		out, err := Execute("print "+fn, config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Log(out)
+	})
+
 	t.Run("cyclonedx", func(t *testing.T) {
 		f := MustOpen(cyclonedxTestReport, t)
 		out, err := Execute("print "+f.Name(), config)

--- a/pkg/artifacts/gitleaks/gitleaks.go
+++ b/pkg/artifacts/gitleaks/gitleaks.go
@@ -63,16 +63,16 @@ func (d *ReportDecoder) DecodeFrom(r io.Reader) (any, error) {
 }
 
 func (d *ReportDecoder) Decode() (any, error) {
-	// Edge Case: report with no findings
-	if d.String() == "[]" {
-		return &ScanReport{}, nil
-	}
-
 	obj := ScanReport{}
-	err := json.NewDecoder(d).Decode(&obj)
-
+	jsonDecoder := json.NewDecoder(d)
+	jsonDecoder.DisallowUnknownFields()
+	err := jsonDecoder.Decode(&obj)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", gce.ErrEncoding, err)
+	}
+	if len(obj) == 0 {
+		log.Info("decoded a gitleaks report with no findings")
+		return &obj, nil
 	}
 
 	if obj[0].RuleID == "" {

--- a/pkg/artifacts/gitleaks/gitleaks_test.go
+++ b/pkg/artifacts/gitleaks/gitleaks_test.go
@@ -14,25 +14,46 @@ import (
 
 const TestReport string = "../../../test/gitleaks-report.json"
 
-func TestEncoding_success(t *testing.T) {
-	decoder := NewReportDecoder()
-	obj, err := decoder.DecodeFrom(MustOpen(TestReport, t))
-	if err != nil {
-		t.Fatal(err)
-	}
-	report, ok := obj.(*ScanReport)
-	if !ok {
-		t.Fatalf("want: *ScanReport got: %T", obj)
-	}
-	if len(*report) < 2 {
-		t.Fatalf("want: <2 got: %d", len(*report))
-	}
+func TestEncoding(t *testing.T) {
+	t.Run("sucess", func(t *testing.T) {
+		decoder := NewReportDecoder()
+		obj, err := decoder.DecodeFrom(MustOpen(TestReport, t))
+		if err != nil {
+			t.Fatal(err)
+		}
+		report, ok := obj.(*ScanReport)
+		if !ok {
+			t.Fatalf("want: *ScanReport got: %T", obj)
+		}
+		if len(*report) < 2 {
+			t.Fatalf("want: <2 got: %d", len(*report))
+		}
 
-	t.Log(report.String())
-	t.Log(decoder.FileType())
-	if !strings.Contains(report.String(), "generic-api-key") {
-		t.Fatal("'generic-api-key' should exist in string")
-	}
+		t.Log(report.String())
+		t.Log(decoder.FileType())
+		if !strings.Contains(report.String(), "generic-api-key") {
+			t.Fatal("'generic-api-key' should exist in string")
+		}
+	})
+	t.Run("invalid-report", func(t *testing.T) {
+		decoder := NewReportDecoder()
+		_, err := decoder.DecodeFrom(strings.NewReader("[{\"name\":\"bacchus\"}]\n"))
+		if !errors.Is(err, gce.ErrEncoding) {
+			t.Fatalf("want: %v got: %v", gce.ErrEncoding, err)
+		}
+	})
+	t.Run("no-serects", func(t *testing.T) {
+		decoder := NewReportDecoder()
+		obj, err := decoder.DecodeFrom(strings.NewReader("[]\n"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		report, ok := obj.(*ScanReport)
+		if !ok {
+			t.Fatalf("want: *ScanReport got: %T", obj)
+		}
+		t.Log(report)
+	})
 }
 
 type badReader struct{}

--- a/pkg/artifacts/gitleaks/gitleaks_test.go
+++ b/pkg/artifacts/gitleaks/gitleaks_test.go
@@ -15,7 +15,7 @@ import (
 const TestReport string = "../../../test/gitleaks-report.json"
 
 func TestEncoding(t *testing.T) {
-	t.Run("sucess", func(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
 		decoder := NewReportDecoder()
 		obj, err := decoder.DecodeFrom(MustOpen(TestReport, t))
 		if err != nil {


### PR DESCRIPTION
This bug was caused because of a newline character at the end of an empty report which is valid JSON.
Resolved by changing the Gitleaks decoder to use a strict decoding method instead of manually checking the string for empty reports.
